### PR TITLE
feat: add types declaration

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,13 @@
 		"nyc": "^15.1.0",
 		"prettier-elastic": "^2.1.2"
 	},
+	"typesVersions": {
+		">=4": {
+			"*": [
+				"ts-types/*"
+			]
+		}
+	},
 	"husky": {
 		"hooks": {
 			"pre-commit": "lint-staged"

--- a/ts-types/array-length/coerce.d.ts
+++ b/ts-types/array-length/coerce.d.ts
@@ -1,0 +1,2 @@
+declare function coerceToArrayLength(value: any): number | null;
+export default coerceToArrayLength;

--- a/ts-types/array-length/ensure.d.ts
+++ b/ts-types/array-length/ensure.d.ts
@@ -1,0 +1,4 @@
+import { EnsureOptions } from '../ensure';
+
+declare function ensureArrayLength(value: any, options?: EnsureOptions): number;
+export default ensureArrayLength;

--- a/ts-types/array-like/ensure.d.ts
+++ b/ts-types/array-like/ensure.d.ts
@@ -1,0 +1,7 @@
+import { EnsureOptions } from '../ensure';
+
+type LengthwiseObject = { length: number } & object;
+type ArrayLikeEnsureOptions = { allowString?: boolean } | EnsureOptions;
+
+declare function ensureArrayLike<T>(value: any, options?: ArrayLikeEnsureOptions): T[] | string | LengthwiseObject;
+export default ensureArrayLike;

--- a/ts-types/array-like/is.d.ts
+++ b/ts-types/array-like/is.d.ts
@@ -1,0 +1,2 @@
+declare function isArrayLike(value: any, options?: {allowString?: boolean}): boolean;
+export default isArrayLike;

--- a/ts-types/array/ensure.d.ts
+++ b/ts-types/array/ensure.d.ts
@@ -1,0 +1,6 @@
+import { EnsureFunction, EnsureOptions } from '../ensure';
+
+type EnsureArrayOptions = { ensureItem?: EnsureFunction } | EnsureOptions;
+
+declare function ensureArray<T>(value: any, options?: EnsureArrayOptions): T[];
+export default ensureArray;

--- a/ts-types/array/is.d.ts
+++ b/ts-types/array/is.d.ts
@@ -1,0 +1,2 @@
+declare function isArray(value: any): boolean;
+export default isArray;

--- a/ts-types/constructor/ensure.d.ts
+++ b/ts-types/constructor/ensure.d.ts
@@ -1,0 +1,4 @@
+import { EnsureFunction, EnsureOptions } from '../ensure';
+
+declare function ensureConstructor(value: any, options?: EnsureOptions): EnsureFunction | object;
+export default ensureConstructor;

--- a/ts-types/constructor/is.d.ts
+++ b/ts-types/constructor/is.d.ts
@@ -1,0 +1,2 @@
+declare function isConstructor(value: any): boolean;
+export default isConstructor;

--- a/ts-types/date/ensure.d.ts
+++ b/ts-types/date/ensure.d.ts
@@ -1,0 +1,4 @@
+import { EnsureOptions } from '../ensure';
+
+declare function ensureDate(value: any, options?: EnsureOptions): Date;
+export default ensureDate;

--- a/ts-types/date/is.d.ts
+++ b/ts-types/date/is.d.ts
@@ -1,0 +1,2 @@
+declare function isDate(value: any): boolean;
+export default isDate;

--- a/ts-types/ensure.d.ts
+++ b/ts-types/ensure.d.ts
@@ -1,0 +1,16 @@
+export type EnsureFunction = (...args: any[]) => any;
+export interface EnsureOptions {
+	name?: string;
+	isOptional?: boolean;
+	default?: any;
+	errorMessage?: string;
+	errorCode?: number;
+	Error?: ErrorConstructor;
+}
+
+type ValidationDatum = [argumentName: string, inputValue: any, ensureFunction: EnsureFunction, options?: object];
+type ValidationDatumList = ValidationDatum[];
+
+declare function ensure<T>(...args: [...ValidationDatumList, EnsureOptions]): T;
+declare function ensure<T>(...args: [...ValidationDatumList]): T;
+export default ensure;

--- a/ts-types/error/ensure.d.ts
+++ b/ts-types/error/ensure.d.ts
@@ -1,0 +1,4 @@
+import { EnsureOptions } from '../ensure';
+
+declare function ensureError(value: any, options?: EnsureOptions): Error;
+export default ensureError;

--- a/ts-types/error/is.d.ts
+++ b/ts-types/error/is.d.ts
@@ -1,0 +1,2 @@
+declare function isError(value: any): boolean;
+export default isError;

--- a/ts-types/finite/coerce.d.ts
+++ b/ts-types/finite/coerce.d.ts
@@ -1,0 +1,2 @@
+declare function coerceToFinite(value: any): number | null;
+export default coerceToFinite;

--- a/ts-types/finite/ensure.d.ts
+++ b/ts-types/finite/ensure.d.ts
@@ -1,0 +1,4 @@
+import { EnsureOptions } from '../ensure';
+
+declare function ensureFinite(value: any, options?: EnsureOptions): number;
+export default ensureFinite;

--- a/ts-types/function/ensure.d.ts
+++ b/ts-types/function/ensure.d.ts
@@ -1,0 +1,4 @@
+import { EnsureFunction, EnsureOptions } from '../ensure';
+
+declare function ensureFunction(value: any, options?: EnsureOptions): EnsureFunction;
+export default ensureFunction;

--- a/ts-types/function/is.d.ts
+++ b/ts-types/function/is.d.ts
@@ -1,0 +1,2 @@
+declare function isFunction(value: any): boolean;
+export default isFunction;

--- a/ts-types/integer/coerce.d.ts
+++ b/ts-types/integer/coerce.d.ts
@@ -1,0 +1,2 @@
+declare function coerceToInteger(value: any): number | null;
+export default coerceToInteger;

--- a/ts-types/integer/ensure.d.ts
+++ b/ts-types/integer/ensure.d.ts
@@ -1,0 +1,4 @@
+import { EnsureOptions } from '../ensure';
+
+declare function ensureInteger(value: any, options?: EnsureOptions): number;
+export default ensureInteger;

--- a/ts-types/iterable/ensure.d.ts
+++ b/ts-types/iterable/ensure.d.ts
@@ -1,0 +1,6 @@
+import { EnsureFunction, EnsureOptions } from '../ensure';
+
+type IterableEnsureOptions = { ensureItem?: EnsureFunction, allowString?: boolean, denyEmpty?: boolean} | EnsureOptions;
+
+declare function ensureIterable<T>(value: any, options?: IterableEnsureOptions): T[];
+export default ensureIterable;

--- a/ts-types/iterable/is.d.ts
+++ b/ts-types/iterable/is.d.ts
@@ -1,0 +1,2 @@
+declare function isIterable(value: any, options?: { allowString?: boolean, denyEmpty?: boolean }): boolean;
+export default isIterable;

--- a/ts-types/map/ensure.d.ts
+++ b/ts-types/map/ensure.d.ts
@@ -1,0 +1,4 @@
+import { EnsureOptions } from '../ensure';
+
+declare function ensureMap<K, V>(value: any, options?: EnsureOptions): Map<K, V>;
+export default ensureMap;

--- a/ts-types/map/is.d.ts
+++ b/ts-types/map/is.d.ts
@@ -1,0 +1,2 @@
+declare function isMap(value: any): boolean;
+export default isMap;

--- a/ts-types/natural-number/coerce.d.ts
+++ b/ts-types/natural-number/coerce.d.ts
@@ -1,0 +1,2 @@
+declare function coerceToNaturalNumber(value: any): number | null;
+export default coerceToNaturalNumber;

--- a/ts-types/natural-number/ensure.d.ts
+++ b/ts-types/natural-number/ensure.d.ts
@@ -1,0 +1,4 @@
+import { EnsureOptions } from '../ensure';
+
+declare function ensureNaturalNumber(value: any, options?: EnsureOptions): number;
+export default ensureNaturalNumber;

--- a/ts-types/number/coerce.d.ts
+++ b/ts-types/number/coerce.d.ts
@@ -1,0 +1,2 @@
+declare function coerceToNumber(value: any): number | null;
+export default coerceToNumber;

--- a/ts-types/number/ensure.d.ts
+++ b/ts-types/number/ensure.d.ts
@@ -1,0 +1,4 @@
+import { EnsureOptions } from '../ensure';
+
+declare function ensureNumber(value: any, options?: EnsureOptions): number;
+export default ensureNumber;

--- a/ts-types/object/ensure.d.ts
+++ b/ts-types/object/ensure.d.ts
@@ -1,0 +1,4 @@
+import { EnsureOptions } from '../ensure';
+
+declare function ensureObject(value: any, options?: EnsureOptions): object;
+export default ensureObject;

--- a/ts-types/object/is.d.ts
+++ b/ts-types/object/is.d.ts
@@ -1,0 +1,2 @@
+declare function isObject(value: any): boolean;
+export default isObject;

--- a/ts-types/plain-function/ensure.d.ts
+++ b/ts-types/plain-function/ensure.d.ts
@@ -1,0 +1,4 @@
+import { EnsureFunction, EnsureOptions } from '../ensure';
+
+declare function ensurePlainFunction(value: any, options?: EnsureOptions): EnsureFunction;
+export default ensurePlainFunction;

--- a/ts-types/plain-function/is.d.ts
+++ b/ts-types/plain-function/is.d.ts
@@ -1,0 +1,2 @@
+declare function isPlainFunction(value: any): boolean;
+export default isPlainFunction;

--- a/ts-types/plain-object/ensure.d.ts
+++ b/ts-types/plain-object/ensure.d.ts
@@ -1,0 +1,6 @@
+import { EnsureFunction, EnsureOptions } from '../ensure';
+
+type PlainObjectEnsureOptions = {allowedKeys?: string[], ensurePropertyValue?: EnsureFunction} | EnsureOptions;
+
+declare function ensurePlainObject(value: any, options?: PlainObjectEnsureOptions): object;
+export default ensurePlainObject;

--- a/ts-types/plain-object/is.d.ts
+++ b/ts-types/plain-object/is.d.ts
@@ -1,0 +1,2 @@
+declare function isPlainObject(value: any): boolean;
+export default isPlainObject;

--- a/ts-types/promise/ensure.d.ts
+++ b/ts-types/promise/ensure.d.ts
@@ -1,0 +1,4 @@
+import { EnsureOptions } from '../ensure';
+
+declare function ensurePromise<T>(value: any, options?: EnsureOptions): Promise<T>;
+export default ensurePromise;

--- a/ts-types/promise/is.d.ts
+++ b/ts-types/promise/is.d.ts
@@ -1,0 +1,2 @@
+declare function isPromise(value: any): boolean;
+export default isPromise;

--- a/ts-types/prototype/is.d.ts
+++ b/ts-types/prototype/is.d.ts
@@ -1,0 +1,2 @@
+declare function isPrototype(value: any): boolean;
+export default isPrototype;

--- a/ts-types/reg-exp/ensure.d.ts
+++ b/ts-types/reg-exp/ensure.d.ts
@@ -1,0 +1,4 @@
+import { EnsureOptions } from '../ensure';
+
+declare function ensureRegExp(value: any, options?: EnsureOptions): RegExp;
+export default ensureRegExp;

--- a/ts-types/reg-exp/is.d.ts
+++ b/ts-types/reg-exp/is.d.ts
@@ -1,0 +1,2 @@
+declare function isRegExp(value: any): boolean;
+export default isRegExp;

--- a/ts-types/safe-integer/coerce.d.ts
+++ b/ts-types/safe-integer/coerce.d.ts
@@ -1,0 +1,2 @@
+declare function coerceToSafeInteger(value: any): number | null;
+export default coerceToSafeInteger;

--- a/ts-types/safe-integer/ensure.d.ts
+++ b/ts-types/safe-integer/ensure.d.ts
@@ -1,0 +1,4 @@
+import { EnsureOptions } from '../ensure';
+
+declare function ensureSafeInteger(value: any, options?: EnsureOptions): number;
+export default ensureSafeInteger;

--- a/ts-types/set/ensure.d.ts
+++ b/ts-types/set/ensure.d.ts
@@ -1,0 +1,4 @@
+import { EnsureOptions } from '../ensure';
+
+declare function ensureSet<T>(value: any, options?: EnsureOptions): Set<T>;
+export default ensureSet;

--- a/ts-types/set/is.d.ts
+++ b/ts-types/set/is.d.ts
@@ -1,0 +1,2 @@
+declare function isSet(value: any): boolean;
+export default isSet;

--- a/ts-types/string/coerce.d.ts
+++ b/ts-types/string/coerce.d.ts
@@ -1,0 +1,2 @@
+declare function coerceToString(value: any): string | null;
+export default coerceToString;

--- a/ts-types/string/ensure.d.ts
+++ b/ts-types/string/ensure.d.ts
@@ -1,0 +1,4 @@
+import { EnsureOptions } from '../ensure';
+
+declare function ensureString(value: any, options?: EnsureOptions): string;
+export default ensureString;

--- a/ts-types/thenable/ensure.d.ts
+++ b/ts-types/thenable/ensure.d.ts
@@ -1,0 +1,5 @@
+import { EnsureFunction, EnsureOptions } from '../ensure';
+type ThenableObject = { then: EnsureFunction } & object;
+
+declare function ensureThenable<T>(value: any, options?: EnsureOptions): Promise<T> | ThenableObject;
+export default ensureThenable;

--- a/ts-types/thenable/is.d.ts
+++ b/ts-types/thenable/is.d.ts
@@ -1,0 +1,2 @@
+declare function isThenable(value: any): boolean;
+export default isThenable;

--- a/ts-types/time-value/coerce.d.ts
+++ b/ts-types/time-value/coerce.d.ts
@@ -1,0 +1,2 @@
+declare function coerceToTimeValue(value: any): number | null;
+export default coerceToTimeValue;

--- a/ts-types/time-value/ensure.d.ts
+++ b/ts-types/time-value/ensure.d.ts
@@ -1,0 +1,4 @@
+import { EnsureOptions } from '../ensure';
+
+declare function ensureTimeValue(value: any, options?: EnsureOptions): number;
+export default ensureTimeValue;

--- a/ts-types/value/ensure.d.ts
+++ b/ts-types/value/ensure.d.ts
@@ -1,0 +1,4 @@
+import { EnsureOptions } from '../ensure';
+
+declare function ensureValue<T>(value: any, options?: EnsureOptions): T;
+export default ensureValue;

--- a/ts-types/value/is.d.ts
+++ b/ts-types/value/is.d.ts
@@ -1,0 +1,2 @@
+declare function isValue(value: any): boolean;
+export default isValue;


### PR DESCRIPTION
Hi @medikoo pls have a look and let me know.


to test this i've use the `npm run test type` in `DefinitelyTyped` to check the signatures.

To test the types in a project:
```
# test in an angular app 
npm install -g @angular/cli
ng new my-app
npm i https://github.com/borracciaBlu/type#feat/add-types
```

Then within the code you may have:
```
import ensure from 'type/ensure';
import ensureString from 'type/string/ensure';
import ensureNaturalNumber from 'type/natural-number/ensure';


var [repoName, issueNumber] = ensure(
      ["repoName", 1, ensureString],
      ["issueNumber", 3, ensureNaturalNumber],
      { Error: {message: "test"} }
);
```


To debug ts resolution:
```
./node_modules/.bin/tsc --noEmit --traceResolution
```

Let me know if you want me to add some example within the `README.md`. 




